### PR TITLE
backlog-translations

### DIFF
--- a/en/translation.json
+++ b/en/translation.json
@@ -469,5 +469,9 @@
   "cli_github_verifier": "CLI Github Verifier",
   "buy_with_ramp": "Buy with Ramp",
   "buy_with_banxa": "Buy with Banxa",
-  "starkcet": "Starkcet"
+  "starkcet": "Starkcet",
+  "backlog": "Backlog",
+  "avg_txns_queue_today": "Daily average of transactions in queue",
+  "avg_queue_delay_today": "Daily average of queue delay",
+  "avg_queue_time_today": "Daily average of queue time"
 }

--- a/fr/translation.json
+++ b/fr/translation.json
@@ -469,5 +469,9 @@
   "cli_github_verifier": "Vérificateur CLI Github",
   "buy_with_ramp": "Acheter avec Rampe",
   "buy_with_banxa": "Acheter avec Banxa",
-  "starkcet": "Starkçet"
+  "starkcet": "Starkçet",
+  "backlog": "Arriéré",
+  "avg_txns_queue_today": "Moyenne quotidienne des transactions en file d'attente",
+  "avg_queue_delay_today": "Moyenne quotidienne du retard de la file d'attente",
+  "avg_queue_time_today": "Moyenne quotidienne du temps d'attente"
 }

--- a/ja/translation.json
+++ b/ja/translation.json
@@ -474,5 +474,9 @@
   "cli_github_verifier": "CLI Github ベリファイアー",
   "buy_with_ramp": "ランプで購入する",
   "buy_with_banxa": "Banxa で購入する",
-  "starkcet": "スターケット"
+  "starkcet": "スターケット",
+  "backlog": "Backlog",
+  "avg_txns_queue_today": "Daily average of transactions in queue",
+  "avg_queue_delay_today": "Daily average of queue delay",
+  "avg_queue_time_today": "Daily average of queue time"
 }

--- a/ko/translation.json
+++ b/ko/translation.json
@@ -469,5 +469,9 @@
   "cli_github_verifier": "CLI Github 검증자",
   "buy_with_ramp": "램프로 구매",
   "buy_with_banxa": "Banxa로 구매",
-  "starkcet": "스타크셋"
+  "starkcet": "스타크셋",
+  "backlog": "Backlog",
+  "avg_txns_queue_today": "Daily average of transactions in queue",
+  "avg_queue_delay_today": "Daily average of queue delay",
+  "avg_queue_time_today": "Daily average of queue time"
 }


### PR DESCRIPTION
Adding keys for backlog metrics on analytics page

For French: used google
For Japanese and Korean: added keys with values in english